### PR TITLE
feat: add New Agent form & routes

### DIFF
--- a/app/agents/new/page.tsx
+++ b/app/agents/new/page.tsx
@@ -1,0 +1,18 @@
+/* app/(chat)/agents/new/page.tsx */
+import AgentForm from '@/components/agents/AgentForm';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function NewAgentPage() {
+  return (
+    <div className="flex justify-center p-6">
+      <Card className="w-full max-w-xl">
+        <CardHeader>
+          <CardTitle>Create New Agent</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <AgentForm />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/agents/AgentForm.tsx
+++ b/components/agents/AgentForm.tsx
@@ -1,0 +1,92 @@
+/* components/agents/AgentForm.tsx */
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { createAgent } from '@/lib/api';
+import { useRouter } from 'next/navigation';
+import { toast } from '@/components/layout/toast';
+
+type FormData = {
+  name: string;
+  provider: string;
+  model: string;
+  baseUrl: string;
+  temperature: number;
+  maxTokens: number;
+};
+
+export default function AgentForm() {
+  const { register, handleSubmit, formState } = useForm<FormData>({
+    defaultValues: {
+      provider: 'ollama',
+      model: 'llama3:8b-instruct-q4_K_M',
+      baseUrl: 'http://host.docker.internal:11434',
+      temperature: 0.7,
+      maxTokens: 2048,
+    },
+  });
+  const router = useRouter();
+
+  async function onSubmit(data: FormData) {
+    const ok = await createAgent({
+      name: data.name,
+      description: `${data.provider} – ${data.model}`,
+      config: {
+        PROVIDER: data.provider,
+        MODEL: data.model,
+        BASE_URL: data.baseUrl,
+        TEMPERATURE: data.temperature,
+        MAX_TOKENS: data.maxTokens,
+      },
+    });
+
+    if (ok) {
+      toast({ title: 'Success', description: 'Agent created 🎉', variant: 'default' });
+      router.push('/chat'); // 跳回聊天页
+    } else {
+      toast({ title: 'Error', description: 'Create failed', variant: 'destructive' });
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div>
+        <Label>Agent Name</Label>
+        <Input {...register('name', { required: true })} placeholder="local-llama" />
+      </div>
+
+      <div>
+        <Label>Provider</Label>
+        <Input {...register('provider', { required: true })} placeholder="ollama" />
+      </div>
+
+      <div>
+        <Label>Model Tag</Label>
+        <Input {...register('model', { required: true })} placeholder="llama3:8b-instruct-q4_K_M" />
+      </div>
+
+      <div>
+        <Label>Base URL</Label>
+        <Input {...register('baseUrl', { required: true })} placeholder="http://host.docker.internal:11434" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <Label>Temperature</Label>
+          <Input type="number" step="0.1" {...register('temperature', { valueAsNumber: true })} />
+        </div>
+        <div>
+          <Label>Max Tokens</Label>
+          <Input type="number" {...register('maxTokens', { valueAsNumber: true })} />
+        </div>
+      </div>
+
+      <Button disabled={formState.isSubmitting} className="w-full">
+        {formState.isSubmitting ? 'Creating…' : 'Create'}
+      </Button>
+    </form>
+  );
+}


### PR DESCRIPTION
### ✨ What’s new
- **/agents/new** route: visual *New Agent* form  
- **components/agents/AgentForm.tsx** refactored for reuse (validation / toast / redirect)  
- **Sidebar**: add **➕ New Agent** top-level menu item  
- `lib/api.ts` › `createAgent()` wraps `POST /api/agent/create`

---

### 🖼️ Screenshots
![image](https://github.com/user-attachments/assets/abe4bedf-6356-4115-b53d-a7d528bae5df)

| Page | Preview |
| ---- | ------- |
| Sidebar | <!-- sidebar screenshot --> |
| New Agent Form | <!-- form screenshot --> |

---

### 🧪 How to test
1. Ensure backend `POST /api/agent/create` works  
2. `npm run dev` (or Docker build) to start frontend  
3. Click **➕ New Agent** in sidebar → fill form → **Create**  
4. On *200 OK* you’re redirected to `/chat`; check `/api/agent/list` – new agent present

---

### ⚙️ Technical details
- **Next.js 14 + shadcn/ui**  
- Controlled inputs with validation; `toast()` for success/error  
- Route file: `app/agents/new/page.tsx`  
- Menu item added in `app/NavMenuItems.tsx`

---

### 📝 Checklist
- [x] `npm run lint` & `npm run type-check` pass  
- [x] `next build` succeeds locally  
- [ ] Update docs / README if needed  
- [ ] Reviewer: @Josh-XT

---

**Related Issue**: #<!-- issue number -->


### ✨ 主要变更
- **/agents/new** 路由：图形化 “新建 Agent” 表单  
- **components/agents/AgentForm.tsx**：抽成可复用组件（校验 / toast / 提交后跳转）  
- **Sidebar**：顶级菜单新增 **➕ New Agent**  
- 新建 `lib/api.ts → createAgent()`，封装 `POST /api/agent/create`

---

### 🖼️ 截图
![image](https://github.com/user-attachments/assets/acddbc93-7659-4f43-b919-2fd22c9965b1)

| 页面 | 效果 |
| ---- | ---- |
| 侧边栏 | <!-- sidebar screenshot --> |
| 表单页 | <!-- form screenshot --> |

---

### 🧪 测试步骤
1. 后端接口 `POST /api/agent/create` 可正常返回  
2. 前端 `npm run dev` 或 Docker 启动  
3. 侧栏点击 **➕ New Agent** → 填表 → **Create**  
4. 返回 200 后自动跳转 `/chat`，再查 `/api/agent/list` 可看到新 Agent

---

### ⚙️ 技术细节
- 基于 **Next.js 14 + shadcn/ui**  
- 受控表单 + 简单校验，使用 `toast()` 展示成功 / 失败  
- 路由文件：`app/agents/new/page.tsx`  
- 菜单配置：`app/NavMenuItems.tsx`

---

### 📝 待办清单
- [x] 通过 `npm run lint` 与 `npm run type-check`  
- [x] 本地 `next build` ✅  
- [ ] 如有需要更新文档 / README  
- [ ] Reviewer：@Josh-XT

---

**关联 Issue**：#<!-- issue number -->
